### PR TITLE
Stop Using Deprecated ModMenu API

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -17,7 +17,9 @@
   "environment": "*",
   "icon": "assets/team_reborn_energy/icon.png",
   "custom": {
-    "modmenu:api": true
+    "modmenu": {
+      "badges": [ "library" ]
+    }
   },
   "entrypoints": {
     "main": [


### PR DESCRIPTION
Fixes `WARNING! Mod team_reborn_energy is only using deprecated 'modmenu:api' custom value! This will be removed in 1.18 snapshots, so ask the author of this mod to support the new API.` being logged whenever you load Minecraft.