### PR TITLE
Energy API v2.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,15 @@ An Energy API for Fabric mods, originally written for TechReborn.
 
 Uses Fabric's API Lookup and Transaction systems.
 
-# Reference Values
+# Conventions
+To ensure good interop between all the mods using this API, here are a few conventions that should be followed.
 
-* 1 coal = 4000
-* 1 plank = 750
+* Reference energy values
+  * 1 coal = 4000
+  * 1 plank = 750
+* The system is push-based.
+  * This means that power sources are responsible for pushing power to nearby machines.
+  * Machines and wires should NOT pull power from other sources.
 
 # Including the API in your project
 
@@ -105,7 +110,7 @@ try (Transaction transaction = Transaction.openOuter()) {
 ```
 
 ## Creating chargeable items
-The easiest way to create an item that can be charged by supported mods is by implementing `SimpleBatteryItem` on your item class.
+The easiest way to create an item that can be charged by supported mods is by implementing `SimpleEnergyItem` on your item class.
 The functions should be self-explanatory.
 
 For more complex items, `EnergyStorage.ITEM` may be used directly.

--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ dependencies {
 
 	modApi fabricApi.module("fabric-transfer-api-v1", project.fabric_version)
 
-	testImplementation 'junit:junit:4.13.2'
+	testmodImplementation 'junit:junit:4.13.2'
 }
 
 processResources {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 # Done to increase the memory available to gradle.
 org.gradle.jvmargs=-Xmx1G
 
-mod_version=2.2.0
+mod_version=2.3.0
 
 # Fabric Properties
 # check these on https://fabricmc.net/versions.html

--- a/src/main/java/team/reborn/energy/api/EnergyStorage.java
+++ b/src/main/java/team/reborn/energy/api/EnergyStorage.java
@@ -8,7 +8,7 @@ import net.fabricmc.fabric.api.transfer.v1.transaction.TransactionContext;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.math.Direction;
 import team.reborn.energy.api.base.DelegatingEnergyStorage;
-import team.reborn.energy.api.base.SimpleBatteryItem;
+import team.reborn.energy.api.base.SimpleEnergyItem;
 import team.reborn.energy.api.base.SimpleEnergyStorage;
 import team.reborn.energy.api.base.SimpleSidedEnergyContainer;
 import team.reborn.energy.impl.EnergyImpl;
@@ -37,13 +37,18 @@ public interface EnergyStorage {
 	 * The {@code Direction} parameter may never be null.
 	 * Refer to {@link BlockApiLookup} for documentation on how to use this field.
 	 *
+	 * <p>The system is push based. That means that power sources are responsible for pushing power to nearby machines.
+	 * Machines and wires should NOT pull power from other sources.
+	 *
 	 * <p>{@link SimpleEnergyStorage} and {@link SimpleSidedEnergyContainer} are provided as base implementations.
 	 *
 	 * <p>When the operations supported by an energy storage change,
 	 * that is if the return value of {@link EnergyStorage#supportsInsertion} or {@link EnergyStorage#supportsExtraction} changes,
 	 * the storage should notify its neighbors with a block update so that they can refresh their connections if necessary.
 	 *
-	 * <p>May only be queried on the logical server thread, never client-side or from another thread!
+	 * <p>This may be queried safely both on the logical server and on the logical client threads.
+	 * On the server thread (i.e. with a server world), all transfer functionality is always supported.
+	 * On the client thread (i.e. with a client world), contents of queried EnergyStorages are unreliable and should not be modified.
 	 */
 	BlockApiLookup<EnergyStorage, Direction> SIDED =
 			BlockApiLookup.get(new Identifier("teamreborn:sided_energy"), EnergyStorage.class, Direction.class);
@@ -53,7 +58,7 @@ public interface EnergyStorage {
 	 * Querying should always happen through {@link ContainerItemContext#find}.
 	 *
 	 * <p>{@link SimpleItemEnergyStorageImpl} is provided as an implementation example.
-	 * Instances of it can be optained through {@link SimpleBatteryItem#createStorage}.
+	 * Instances of it can be optained through {@link SimpleEnergyItem#createStorage}.
 	 * Custom implementations should treat the context as a wrapper around a single slot,
 	 * and always check the current item variant and amount before any operation, like {@code SimpleItemEnergyStorageImpl} does it.
 	 * The check can be handled by {@link DelegatingEnergyStorage}.

--- a/src/main/java/team/reborn/energy/api/base/SimpleEnergyItem.java
+++ b/src/main/java/team/reborn/energy/api/base/SimpleEnergyItem.java
@@ -8,22 +8,20 @@ import team.reborn.energy.api.EnergyStorage;
 import team.reborn.energy.impl.SimpleItemEnergyStorageImpl;
 
 /**
- * Simple battery-like item. If this is implemented on an item:
+ * Simple battery-like energy containing item. If this is implemented on an item:
  * <ul>
  *     <li>The energy will directly be stored in the NBT.</li>
  *     <li>Helper functions in this class to work with the stored energy can be used.</li>
  *     <li>An EnergyStorage will automatically be provided for queries through {@link EnergyStorage#ITEM}.</li>
  * </ul>
- *
- * @deprecated Use {@link SimpleEnergyItem} instead, it has stack-aware capacity and transfer limits.
  */
-@Deprecated
-public interface SimpleBatteryItem {
+// TODO: Consider adding a tooltip and a recipe input -> output energy transfer handler like RC has.
+public interface SimpleEnergyItem {
 	String ENERGY_KEY = "energy";
 
 	/**
 	 * Return a base energy storage implementation for items, with fixed capacity, and per-operation insertion and extraction limits.
-	 * This is used internally for items that implement SimpleBatteryItem, but it may also be used outside of that.
+	 * This is used internally for items that implement SimpleEnergyItem, but it may also be used outside of that.
 	 * The energy is stored in the {@code energy} tag of the stacks, the same as the constant {@link #ENERGY_KEY}.
 	 *
 	 * <p>Stackable energy containers are supported just fine, and they will distribute energy evenly.
@@ -34,19 +32,22 @@ public interface SimpleBatteryItem {
 	}
 
 	/**
-	 * @return The max energy that can be stored in this item.
+	 * @param stack Current stack.
+	 * @return The max energy that can be stored in this item stack (ignoring current stack size).
 	 */
-	long getEnergyCapacity();
+	long getEnergyCapacity(ItemStack stack);
 
 	/**
-	 * @return The max amount of energy that can be inserted in this item in a single operation.
+	 * @param stack Current stack.
+	 * @return The max amount of energy that can be inserted in this item stack (ignoring current stack size) in a single operation.
 	 */
-	long getEnergyMaxInput();
+	long getEnergyMaxInput(ItemStack stack);
 
 	/**
-	 * @return The max amount of energy that can be extracted from this item in a single operation.
+	 * @param stack Current stack.
+	 * @return The max amount of energy that can be extracted from this item stack (ignoring current stack size) in a single operation.
 	 */
-	long getEnergyMaxOutput();
+	long getEnergyMaxOutput(ItemStack stack);
 
 	/**
 	 * @return The energy stored in the stack. Count is ignored.
@@ -56,7 +57,8 @@ public interface SimpleBatteryItem {
 	}
 
 	/**
-	 * Set the energy stored in the stack. Count is ignored.
+	 * Directly set the energy stored in the stack. Count is ignored.
+	 * It's up to callers to ensure that the new amount is >= 0 and <= capacity.
 	 */
 	default void setStoredEnergy(ItemStack stack, long newAmount) {
 		setStoredEnergyUnchecked(stack, newAmount);

--- a/src/main/java/team/reborn/energy/impl/EnergyImpl.java
+++ b/src/main/java/team/reborn/energy/impl/EnergyImpl.java
@@ -1,13 +1,18 @@
 package team.reborn.energy.impl;
 
 import net.fabricmc.fabric.api.transfer.v1.transaction.TransactionContext;
+import org.jetbrains.annotations.ApiStatus;
 import team.reborn.energy.api.EnergyStorage;
 import team.reborn.energy.api.base.SimpleBatteryItem;
+import team.reborn.energy.api.base.SimpleEnergyItem;
 
+@ApiStatus.Internal
 public class EnergyImpl {
 	static {
 		EnergyStorage.ITEM.registerFallback((stack, ctx) -> {
-			if (stack.getItem() instanceof SimpleBatteryItem battery) {
+			if (stack.getItem() instanceof SimpleEnergyItem energyItem) {
+				return SimpleEnergyItem.createStorage(ctx, energyItem.getEnergyCapacity(stack), energyItem.getEnergyMaxInput(stack), energyItem.getEnergyMaxOutput(stack));
+			} else if (stack.getItem() instanceof SimpleBatteryItem battery) {
 				return SimpleBatteryItem.createStorage(ctx, battery.getEnergyCapacity(), battery.getEnergyMaxInput(), battery.getEnergyMaxOutput());
 			} else {
 				return null;

--- a/src/main/java/team/reborn/energy/impl/SimpleItemEnergyStorageImpl.java
+++ b/src/main/java/team/reborn/energy/impl/SimpleItemEnergyStorageImpl.java
@@ -7,14 +7,16 @@ import net.fabricmc.fabric.api.transfer.v1.transaction.Transaction;
 import net.fabricmc.fabric.api.transfer.v1.transaction.TransactionContext;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
+import org.jetbrains.annotations.ApiStatus;
 import team.reborn.energy.api.EnergyStorage;
 import team.reborn.energy.api.base.DelegatingEnergyStorage;
-import team.reborn.energy.api.base.SimpleBatteryItem;
+import team.reborn.energy.api.base.SimpleEnergyItem;
 
 /**
  * Note: instances of this class do not perform any context validation,
  * that is handled by the DelegatingEnergyStorage they are wrapped behind.
  */
+@ApiStatus.Internal
 @SuppressWarnings({"deprecation", "UnstableApiUsage"})
 public class SimpleItemEnergyStorageImpl implements EnergyStorage {
 	public static EnergyStorage createSimpleStorage(ContainerItemContext ctx, long capacity, long maxInsert, long maxExtract) {
@@ -46,7 +48,7 @@ public class SimpleItemEnergyStorageImpl implements EnergyStorage {
 	 */
 	private boolean trySetEnergy(long energyAmountPerCount, long count, TransactionContext transaction) {
 		ItemStack newStack = ctx.getItemVariant().toStack();
-		SimpleBatteryItem.setStoredEnergyUnchecked(newStack, energyAmountPerCount);
+		SimpleEnergyItem.setStoredEnergyUnchecked(newStack, energyAmountPerCount);
 		ItemVariant newVariant = ItemVariant.of(newStack);
 
 		// Try to convert exactly `count` items.
@@ -106,7 +108,7 @@ public class SimpleItemEnergyStorageImpl implements EnergyStorage {
 
 	@Override
 	public long getAmount() {
-		return ctx.getAmount() * SimpleBatteryItem.getStoredEnergyUnchecked(ctx.getItemVariant().getNbt());
+		return ctx.getAmount() * SimpleEnergyItem.getStoredEnergyUnchecked(ctx.getItemVariant().getNbt());
 	}
 
 	@Override

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -19,6 +19,6 @@
   "depends": {
     "java": ">=16",
     "minecraft": ">=1.17",
-    "fabric": ">=0.40"
+    "fabric-transfer-api-v1": ">=1.3.0"
   }
 }

--- a/src/testmod/java/team/reborn/energy/test/EnergyTests.java
+++ b/src/testmod/java/team/reborn/energy/test/EnergyTests.java
@@ -12,11 +12,11 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import team.reborn.energy.api.EnergyStorage;
 import team.reborn.energy.api.EnergyStorageUtil;
-import team.reborn.energy.api.base.SimpleBatteryItem;
+import team.reborn.energy.api.base.SimpleEnergyItem;
 import team.reborn.energy.api.base.SimpleEnergyStorage;
 
 import static org.junit.Assert.*;
-import static team.reborn.energy.api.base.SimpleBatteryItem.ENERGY_KEY;
+import static team.reborn.energy.api.base.SimpleEnergyItem.ENERGY_KEY;
 
 @SuppressWarnings({"UnstableApiUsage", "deprecation"})
 public class EnergyTests implements ModInitializer {
@@ -79,7 +79,7 @@ public class EnergyTests implements ModInitializer {
 		slot.amount = 2;
 
 		// Create the energy storage
-		EnergyStorage energyStorage = SimpleBatteryItem.createStorage(ctx, 60, 50, 30);
+		EnergyStorage energyStorage = SimpleEnergyItem.createStorage(ctx, 60, 50, 30);
 
 		try (Transaction transaction = Transaction.openOuter()) {
 			assertTrue(energyStorage.supportsInsertion());

--- a/src/testmod/java/team/reborn/energy/test/TestBatteryItem.java
+++ b/src/testmod/java/team/reborn/energy/test/TestBatteryItem.java
@@ -1,9 +1,10 @@
 package team.reborn.energy.test;
 
 import net.minecraft.item.Item;
-import team.reborn.energy.api.base.SimpleBatteryItem;
+import net.minecraft.item.ItemStack;
+import team.reborn.energy.api.base.SimpleEnergyItem;
 
-public class TestBatteryItem extends Item implements SimpleBatteryItem {
+public class TestBatteryItem extends Item implements SimpleEnergyItem {
 	private final long capacity, maxInput, maxOutput;
 
 	public TestBatteryItem(long capacity, long maxInput, long maxOutput) {
@@ -14,17 +15,17 @@ public class TestBatteryItem extends Item implements SimpleBatteryItem {
 	}
 
 	@Override
-	public long getEnergyCapacity() {
+	public long getEnergyCapacity(ItemStack stack) {
 		return capacity;
 	}
 
 	@Override
-	public long getEnergyMaxInput() {
+	public long getEnergyMaxInput(ItemStack stack) {
 		return maxInput;
 	}
 
 	@Override
-	public long getEnergyMaxOutput() {
+	public long getEnergyMaxOutput(ItemStack stack) {
 		return maxOutput;
 	}
 }

--- a/src/testmod/resources/fabric.mod.json
+++ b/src/testmod/resources/fabric.mod.json
@@ -17,9 +17,7 @@
   "environment": "*",
   "icon": "assets/team_reborn_energy/icon.png",
   "depends": {
-    "java": ">=16",
-    "minecraft": ">=1.17",
-    "fabric": ">=0.37.0"
+    "team_reborn_energy": "*"
   },
   "custom": {
     "modmenu:api": true


### PR DESCRIPTION
* Allow querying EnergyStorage.SIDED on the client side for existence checks. (Same as 1.19+ Transfer API storages). Closes #23.
* Define that the system is push-based, i.e. sources should push, but consumers should NOT pull. Closes #22.
* Deprecate `SimpleBatteryItem` in favor of the new `SimpleEnergyItem` which supports stack-aware capacity and I/O limits. Closes #21.
* Clarify that passing a consistent value to `setStoredEnergy` in `SimpleEnergyItem` is the responsibility of the caller. Closes #20.
* Mark implementation classes as `@ApiStatus.Internal`